### PR TITLE
fix reconnect

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -34,12 +34,17 @@ type pubEvent struct {
 func (s *Subscription) Unsubscribe() (err error) {
 
 	for _, sub := range s.subscriptions {
+		log.Printf("[DEBUG] Unsubscribing from %s", sub.Channel)
 		err = sub.Unsubscribe()
 	}
+	log.Printf("[DEBUG] Unsubscribed from subscriptions")
 	if !s.closed {
+		log.Printf("[DEBUG] Closing pubChan")
 		close(s.pubChan)
 	}
+	log.Printf("[DEBUG] Closed pubChan")
 	s.centrifugeClient.Close()
+	log.Printf("[DEBUG] Closed centrifugeClient")
 	s.closed = true
 	return err
 }

--- a/subscription.go
+++ b/subscription.go
@@ -206,6 +206,7 @@ func (jb *Client) SubscribeWithQueue(ctx context.Context, subscriptionID string,
 			time.Sleep(10 * time.Second)
 			_, err = jb.SubscribeWithQueue(ctx, subscriptionID, uint64(currentBlock), currentPage, eventHandler, options)
 			if err != nil {
+				log.Printf("ERROR: failed to reconnect: %v", err)
 				eventHandler.OnError(err)
 			}
 			return

--- a/subscription.go
+++ b/subscription.go
@@ -202,7 +202,11 @@ func (jb *Client) SubscribeWithQueue(ctx context.Context, subscriptionID string,
 				Status:     "reconnecting",
 				Message:    fmt.Sprintf("Reconnecting to server at block %d, page %d", currentBlock, currentPage),
 			})
-			_ = jb.Unsubscribe()
+			err = jb.Unsubscribe()
+			if err != nil {
+				log.Printf("ERROR: failed to unsubscribe: %v", err)
+				eventHandler.OnError(err)
+			}
 			time.Sleep(10 * time.Second)
 			_, err = jb.SubscribeWithQueue(ctx, subscriptionID, uint64(currentBlock), currentPage, eventHandler, options)
 			if err != nil {

--- a/subscription.go
+++ b/subscription.go
@@ -203,7 +203,7 @@ func (jb *Client) SubscribeWithQueue(ctx context.Context, subscriptionID string,
 				Message:    fmt.Sprintf("Reconnecting to server at block %d, page %d", currentBlock, currentPage),
 			})
 			_ = jb.Unsubscribe()
-			time.Sleep(1 * time.Second)
+			time.Sleep(10 * time.Second)
 			_, err = jb.SubscribeWithQueue(ctx, subscriptionID, uint64(currentBlock), currentPage, eventHandler, options)
 			if err != nil {
 				eventHandler.OnError(err)

--- a/subscription.go
+++ b/subscription.go
@@ -31,28 +31,14 @@ type pubEvent struct {
 	Data    []byte
 }
 
-// 2025/02/03 21:38:01 [DEBUG] Unsubscribing from query:5af4235fe3e2a36965a46805a10dd48e0d659467c7f5df0a8c48ba5d32e406dd:mempool
-// 2025/02/03 21:38:01 [DEBUG] Unsubscribing from query:5af4235fe3e2a36965a46805a10dd48e0d659467c7f5df0a8c48ba5d32e406dd:control
-// 2025/02/03 21:38:01 [DEBUG] Unsubscribing from query:5af4235fe3e2a36965a46805a10dd48e0d659467c7f5df0a8c48ba5d32e406dd:882469:0
-// 2025/02/03 21:38:01 [DEBUG] Unsubscribed from subscriptions
-// 2025/02/03 21:38:01 [DEBUG] Closing pubChan
-// 2025/02/03 21:38:01 [DEBUG] Closed pubChan
-// 2025/02/03 21:38:01 Reconnecting to Junglebus
-
 func (s *Subscription) Unsubscribe() (err error) {
-
 	for _, sub := range s.subscriptions {
-		log.Printf("[DEBUG] Unsubscribing from %s", sub.Channel)
 		err = sub.Unsubscribe()
 	}
-	log.Printf("[DEBUG] Unsubscribed from subscriptions")
 	if !s.closed {
-		log.Printf("[DEBUG] Closing pubChan")
 		close(s.pubChan)
 	}
-	log.Printf("[DEBUG] Closed pubChan")
 	go s.centrifugeClient.Close()
-	log.Printf("[DEBUG] Closed centrifugeClient")
 	s.closed = true
 	return err
 }
@@ -220,7 +206,7 @@ func (jb *Client) SubscribeWithQueue(ctx context.Context, subscriptionID string,
 				log.Printf("ERROR: failed to unsubscribe: %v", err)
 				eventHandler.OnError(err)
 			}
-			time.Sleep(10 * time.Second)
+			time.Sleep(1 * time.Second)
 			_, err = jb.SubscribeWithQueue(ctx, subscriptionID, uint64(currentBlock), currentPage, eventHandler, options)
 			if err != nil {
 				log.Printf("ERROR: failed to reconnect: %v", err)

--- a/subscription.go
+++ b/subscription.go
@@ -31,6 +31,14 @@ type pubEvent struct {
 	Data    []byte
 }
 
+// 2025/02/03 21:38:01 [DEBUG] Unsubscribing from query:5af4235fe3e2a36965a46805a10dd48e0d659467c7f5df0a8c48ba5d32e406dd:mempool
+// 2025/02/03 21:38:01 [DEBUG] Unsubscribing from query:5af4235fe3e2a36965a46805a10dd48e0d659467c7f5df0a8c48ba5d32e406dd:control
+// 2025/02/03 21:38:01 [DEBUG] Unsubscribing from query:5af4235fe3e2a36965a46805a10dd48e0d659467c7f5df0a8c48ba5d32e406dd:882469:0
+// 2025/02/03 21:38:01 [DEBUG] Unsubscribed from subscriptions
+// 2025/02/03 21:38:01 [DEBUG] Closing pubChan
+// 2025/02/03 21:38:01 [DEBUG] Closed pubChan
+// 2025/02/03 21:38:01 Reconnecting to Junglebus
+
 func (s *Subscription) Unsubscribe() (err error) {
 
 	for _, sub := range s.subscriptions {
@@ -43,7 +51,7 @@ func (s *Subscription) Unsubscribe() (err error) {
 		close(s.pubChan)
 	}
 	log.Printf("[DEBUG] Closed pubChan")
-	s.centrifugeClient.Close()
+	go s.centrifugeClient.Close()
 	log.Printf("[DEBUG] Closed centrifugeClient")
 	s.closed = true
 	return err


### PR DESCRIPTION
### **User description**
- fix hang on centrifuge close


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed potential hang during centrifuge client closure.

- Improved error handling during subscription reconnection.

- Added logging for unsubscribe and reconnection errors.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>subscription.go</strong><dd><code>Fix hang and improve reconnection error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

subscription.go

<li>Changed <code>centrifugeClient.Close</code> to run in a goroutine to prevent hangs.<br> <li> Added error handling for <code>Unsubscribe</code> during reconnection.<br> <li> Introduced logging for unsubscribe and reconnection errors.


</details>


  </td>
  <td><a href="https://github.com/b-open-io/go-junglebus/pull/5/files#diff-828fe8a645cf1a278fb0dfdca1eac3d6b4c691415c66dbe854d6286e2578031b">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>