### PR TITLE
Add request concurrency limiter

### DIFF
--- a/client_options.go
+++ b/client_options.go
@@ -76,3 +76,13 @@ func WithVersion(version string) ClientOps {
 		}
 	}
 }
+
+// WithMaxConcurrentRequests sets the maximum number of concurrent HTTP requests.
+// Defaults to 8 if not set.
+func WithMaxConcurrentRequests(n int) ClientOps {
+	return func(c *Client) {
+		if c != nil && c.transport != nil {
+			c.transport.SetMaxConcurrentRequests(n)
+		}
+	}
+}

--- a/transports/client_options.go
+++ b/transports/client_options.go
@@ -39,12 +39,18 @@ func initHTTPTransport(c *Client, serverURL string, httpClient *http.Client) {
 	serverURL = regexReplaceHTTPS.ReplaceAllString(serverURL, "")
 	serverURL = regexReplaceWSS.ReplaceAllString(serverURL, "")
 
+	maxConcurrent := c.maxConcurrentRequests
+	if maxConcurrent == 0 {
+		maxConcurrent = DefaultMaxConcurrentRequests
+	}
+
 	c.transport = NewTransportService(&TransportHTTP{
 		debug:      c.debug,
 		server:     serverURL,
 		httpClient: httpClient,
 		useSSL:     useSSL,
 		version:    "v1",
+		limiter:    make(chan struct{}, maxConcurrent),
 	})
 }
 
@@ -89,6 +95,16 @@ func WithVersion(version string) ClientOps {
 			if c.transport != nil {
 				c.transport.SetVersion(version)
 			}
+		}
+	}
+}
+
+// WithMaxConcurrentRequests sets the maximum number of concurrent HTTP requests.
+// Defaults to DefaultMaxConcurrentRequests (8) if not set or if n <= 0.
+func WithMaxConcurrentRequests(n int) ClientOps {
+	return func(c *Client) {
+		if c != nil {
+			c.maxConcurrentRequests = n
 		}
 	}
 }

--- a/transports/http.go
+++ b/transports/http.go
@@ -13,6 +13,8 @@ import (
 	"github.com/b-open-io/go-junglebus/models"
 )
 
+const DefaultMaxConcurrentRequests = 8
+
 // TransportHTTP is the struct for HTTP
 type TransportHTTP struct {
 	debug      bool
@@ -21,6 +23,7 @@ type TransportHTTP struct {
 	token      string
 	useSSL     bool
 	version    string
+	limiter    chan struct{}
 }
 
 // SetDebug turn the debugging on or off
@@ -98,6 +101,14 @@ func (h *TransportHTTP) GetVersion() string {
 // GetServerURL get the server URL for this transport
 func (h *TransportHTTP) GetServerURL() string {
 	return h.server
+}
+
+// SetMaxConcurrentRequests sets the maximum number of concurrent HTTP requests.
+func (h *TransportHTTP) SetMaxConcurrentRequests(n int) {
+	if n <= 0 {
+		n = DefaultMaxConcurrentRequests
+	}
+	h.limiter = make(chan struct{}, n)
 }
 
 func (h *TransportHTTP) Login(ctx context.Context, username string, password string) error {
@@ -286,8 +297,33 @@ func (h *TransportHTTP) GetChainTip(ctx context.Context) (blockHeader *models.Bl
 	return blockHeader, nil
 }
 
+// acquire blocks until a limiter slot is available or context is cancelled.
+func (h *TransportHTTP) acquire(ctx context.Context) error {
+	if h.limiter == nil {
+		return nil
+	}
+	select {
+	case h.limiter <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// release returns a limiter slot.
+func (h *TransportHTTP) release() {
+	if h.limiter != nil {
+		<-h.limiter
+	}
+}
+
 // doHTTPRequest will create and submit the HTTP request
 func (h *TransportHTTP) doHTTPRequest(ctx context.Context, method string, path string, rawJSON []byte, responseJSON interface{}) error {
+	if err := h.acquire(ctx); err != nil {
+		return err
+	}
+	defer h.release()
+
 	protocol := "https"
 	if !h.useSSL {
 		protocol = "http"

--- a/transports/interface.go
+++ b/transports/interface.go
@@ -57,6 +57,7 @@ type TransportService interface {
 	IsSSL() bool
 	GetServerURL() string
 	GetUser(ctx context.Context) (*models.User, error)
+	SetMaxConcurrentRequests(n int)
 }
 
 // LoginResponse response from server on login or token refresh

--- a/transports/transports.go
+++ b/transports/transports.go
@@ -2,8 +2,9 @@ package transports
 
 // Client is the transport client
 type Client struct {
-	debug     bool
-	transport TransportService
+	debug                 bool
+	transport             TransportService
+	maxConcurrentRequests int
 }
 
 // ClientOps are the client options functions


### PR DESCRIPTION
## Summary
- Adds a channel-based semaphore to `TransportHTTP` that limits concurrent HTTP requests
- Defaults to 8 concurrent requests
- Configurable via `WithMaxConcurrentRequests(n)` at both transport and client level
- Context-aware: blocked callers return immediately on context cancellation

## Motivation
Multiple consumers (BEEF storage, ORDFS, overlay workers) share a single JungleBus client. Without a limiter, bulk operations can flood JungleBus with unbounded concurrent requests, causing HTTP/2 GOAWAY errors.

## Test plan
- [x] Existing tests pass
- [ ] Verify under load with 1sat-stack bulk crawl